### PR TITLE
Us15 linkar monitoria ao perfil

### DIFF
--- a/tutoring_session/serializers.py
+++ b/tutoring_session/serializers.py
@@ -3,12 +3,12 @@ from tutoring_session.models import Solicitation
 from tutoring_session.models import Receipt
 from rest_framework import serializers
 
-class SolicitationSerializer(serializers.HyperlinkedModelSerializer):
+class SolicitationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Solicitation
         fields = ['status_solicitation', 'resquester', 'create_date']
 
-class TutoringSessionSerializer(serializers.HyperlinkedModelSerializer):
+class TutoringSessionSerializer(serializers.ModelSerializer):
     class Meta:
         model = TutoringSession
         fields = ['monitor','id_tutoring_session', 'name', 'subject' ,'applicants',

--- a/tutoring_session/tests.py
+++ b/tutoring_session/tests.py
@@ -1,42 +1,35 @@
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
+from .views import TutoringSessionViewset
+from user_account.models import UserAccount
 from .models import TutoringSession
 
-# from rest_framework.status import (
-#     HTTP_403_FORBIDDEN,
-#     HTTP_200_OK,
-#     HTTP_404_NOT_FOUND,
-#     HTTP_400_BAD_REQUEST,
-#     HTTP_500_INTERNAL_SERVER_ERROR
-# )
 
-
-class TutoringSessionTests(APITestCase):
+class TutoringSessionViewsetTests(APITestCase):
     def setUp(self):
         self.valid_payload = {
-            'name': 'teste'
-            # 'monitor': 'adsfg'
-            # 'name': 'test'
-            # 'subject': 'teste'            
+            'monitor': '211297',
+            'name': 'encapsulamento',
+            'subject': 'Orientação a Objetos',
+            
         }
 
         self.invalid_payload = {
             'name': ''            
         }
+       
+    def test_create_valid_tutoring(self):
+        user = UserAccount(name='moacir', user_account_id="211297", 
+                           email='moacir@moacir', course='AERO')
+        user.save()
+        url = '/tutoring/'
+        data = self.valid_payload
+        response = self.client.post(url, data, format='json')
+        tutoring_session = TutoringSession.objects.latest('create_date')
 
-    
-    # def test_create_valid_tutoring(self):
-    #     url = '/tutoring/'
-    #     data = self.valid_payload
-    #     response = self.client.post(url, data, format='json')
-    #     self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-    #     self.assertEqual(TutoringSession.objects.count(), 1)
-    #     # self.assertEqual(Tutoring.objects.get().name, self.valid_payload['name'])
-    #     # self.assertEqual(Tutoring.objects.get().monitor, self.valid_payload['monitor'])
-    #     self.assertEqual(TutoringSession.objects.get().name, self.valid_payload['name'])
-    #     # self.assertEqual(Tutoring.objects.get().subject, self.valid_payload['subject'])
-
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(tutoring_session in user.monitoring.all(), True)
 
     def test_create_invalid_tutoring(self):
         url = '/tutoring/'

--- a/tutoring_session/tests.py
+++ b/tutoring_session/tests.py
@@ -1,3 +1,45 @@
 from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APITestCase
+from .models import TutoringSession
 
-# Create your tests here.
+# from rest_framework.status import (
+#     HTTP_403_FORBIDDEN,
+#     HTTP_200_OK,
+#     HTTP_404_NOT_FOUND,
+#     HTTP_400_BAD_REQUEST,
+#     HTTP_500_INTERNAL_SERVER_ERROR
+# )
+
+
+class TutoringSessionTests(APITestCase):
+    def setUp(self):
+        self.valid_payload = {
+            'name': 'teste'
+            # 'monitor': 'adsfg'
+            # 'name': 'test'
+            # 'subject': 'teste'            
+        }
+
+        self.invalid_payload = {
+            'name': ''            
+        }
+
+    
+    # def test_create_valid_tutoring(self):
+    #     url = '/tutoring/'
+    #     data = self.valid_payload
+    #     response = self.client.post(url, data, format='json')
+    #     self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+    #     self.assertEqual(TutoringSession.objects.count(), 1)
+    #     # self.assertEqual(Tutoring.objects.get().name, self.valid_payload['name'])
+    #     # self.assertEqual(Tutoring.objects.get().monitor, self.valid_payload['monitor'])
+    #     self.assertEqual(TutoringSession.objects.get().name, self.valid_payload['name'])
+    #     # self.assertEqual(Tutoring.objects.get().subject, self.valid_payload['subject'])
+
+
+    def test_create_invalid_tutoring(self):
+        url = '/tutoring/'
+        data = self.invalid_payload
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/tutoring_session/views.py
+++ b/tutoring_session/views.py
@@ -20,9 +20,7 @@ class TutoringSessionViewset(ModelViewSet):
         headers = self.get_success_headers(serializer.data)
 
         tutoring_session = TutoringSession.objects.latest('create_date')
-
-        monitor = UserAccount.objects.get(pk=request.data['monitor'])
-        monitor.monitoring.add(tutoring_session)        
+        tutoring_session.monitor.monitoring.add(tutoring_session)        
 
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 

--- a/user_account/models.py
+++ b/user_account/models.py
@@ -33,7 +33,3 @@ class UserAccount(models.Model):
     registration_date = models.DateTimeField(auto_now_add=True)
     account_state = models.BooleanField(default=True)
 
-    def __str__(self):
-        return self.name
-
-

--- a/user_account/serializers.py
+++ b/user_account/serializers.py
@@ -1,14 +1,17 @@
 from rest_framework import serializers
+from tutoring_session.serializers import TutoringSessionSerializer
 from .models import UserAccount
 from .models import InterestArea
 
-class UserAccountSerializer(serializers.HyperlinkedModelSerializer):
+class UserAccountSerializer(serializers.ModelSerializer):
+    monitoring = TutoringSessionSerializer(many=True, read_only=True)
+
     class Meta:
         model = UserAccount
         fields = ['user_account_id', 'name', 'email', 'registration_date',
                   'description', 'course', 'account_state', 'photo_url','interest_areas','monitoring','monitoring_history']
 
-class InterestAreaSerializer(serializers.HyperlinkedModelSerializer):
+class InterestAreaSerializer(serializers.ModelSerializer):
     class Meta:
         model = InterestArea
         fields = ['id_interest_area','name']


### PR DESCRIPTION
## Issue resolvida

[ [US15] "Linkar" Monitoria ao Perfil do Usuário que a Criou ](https://github.com/fga-eps-mds/2019.1-MaisMonitoria/issues/125)

## Comentário

A solução implementada foi sobrescrever o método create da classe ModelViewSet, que é a classe da qual herdamos nossa view, pois já nos disponibiliza uma implementação de CRUD para nosso modelo.
No entanto o método create padrão não atendia a nossa demanda de linkar uma monitoria ao usuário que a criou, por isso realizamos a seguinte alteração:

![tutoring](https://user-images.githubusercontent.com/31708472/57653018-3f177180-75a7-11e9-9a53-d7c9ae39fc82.png)

 Após solucionar essa questão, ao tentar realizar a task da issue que diz respeito ao frontend, identificamos uma necessidade de  alterar a forma como os dados do usuário eram serializados para envio por meio dos métodos http. Então optamos por utilizar como base a classe ModelSerializer ao invés da classe HiperLinkedModelSerializer para construção de nossos serializers.

![serializer](https://user-images.githubusercontent.com/31708472/57653525-69b5fa00-75a8-11e9-95b4-7944ab42eb63.png)

Outra questão levantada foi que na forma atual como os dados do usuário eram serializados havia a necessidade de realizar novas requisições pra conseguir recuperar as monitorias que dizem respeito ao usuário, no entanto foi tomada a decisão de enviar junto ao usuário as suas respectivas monitorias aumentando assim o tamanho da requisição, para evitar que todas essas requisições adicionais ou fossem feitas.

![useraccount](https://user-images.githubusercontent.com/31708472/57654025-a0d8db00-75a9-11e9-9aaa-df559584fe0b.png)
Alteração realizada no código.

![image](https://user-images.githubusercontent.com/31708472/57654245-180e6f00-75aa-11e9-8393-4b0771aa9c91.png)
Novo formato do JSON do usuário.

