### PR TITLE
Refatorar Feed

### DIFF
--- a/tutoring_session/views.py
+++ b/tutoring_session/views.py
@@ -8,7 +8,7 @@ from rest_framework.filters import SearchFilter
 
 
 class TutoringSessionViewset(ModelViewSet):
-    queryset = TutoringSession.objects.all()
+    queryset = TutoringSession.objects.all().order_by('-create_date')
     serializer_class = GetTutoringSessionSerializer
     filter_backends = (SearchFilter,)
     search_fields = ('name', 'subject','description')


### PR DESCRIPTION
## Issue resolvida

[[US23] Refatorar feed  ](https://github.com/fga-eps-mds/2019.1-MaisMonitoria/issues/148)

## Comentário

Foram mudadas as ordens das monitorias que aparecem no feed e perfil. As monitorias mais recentes cadastradas agora aparecem acima das mais antigas. 
Foi mudado o queryset, sendo retornada em ordem decrescente de acordo com a data e hora de criação.
 
![image](https://user-images.githubusercontent.com/44438409/58520344-af201d00-818d-11e9-8d49-9012dd034338.png)

